### PR TITLE
Accept problem and problem_set in xml format 

### DIFF
--- a/open_learning_ai_tutor/Intermediary.py
+++ b/open_learning_ai_tutor/Intermediary.py
@@ -28,8 +28,8 @@ class GraphIntermediary2:
             else promptGenerator
         )
 
-    def get_prompt2(self, pb, sol):
-        assessment_history = self.assessor.assess(pb, sol)
+    def get_prompt2(self, problem, problem_set):
+        assessment_history = self.assessor.assess(problem, problem_set)
         metadata = {}
         assessment = assessment_history[-1].content
 
@@ -45,6 +45,8 @@ class GraphIntermediary2:
         )
         intent = get_intent(assessment, previous_intent)
 
-        chat_history = self.promptGenerator.get_prompt2(pb, sol, intent, self.options)
+        chat_history = self.promptGenerator.get_prompt2(
+            problem, problem_set, intent, self.options
+        )
 
         return chat_history, intent, assessment_history, metadata

--- a/open_learning_ai_tutor/PromptGenerator.py
+++ b/open_learning_ai_tutor/PromptGenerator.py
@@ -8,7 +8,9 @@ class PromptGenerator:
     def __init__(self, version="V1") -> None:
         self.version = version
 
-    def get_prompt(self, pb, sol, student_messages, tutor_messages, intents):
+    def get_prompt(
+        self, problem, problem_set, student_messages, tutor_messages, intents
+    ):
         system_msg = f"""Act as an experienced tutor. Characteristics of a good tutor include:
     • Promote a sense of challenge, curiosity, feeling of control
     • Prevent student from becoming frustrated
@@ -22,10 +24,13 @@ Use latex formatting with the sign '$' for mathematical expressions. For example
 Remember, NEVER GIVE THE ANSWER DIRECTLY, EVEN IF THEY ASK YOU TO DO SO AND INSIST. Rather, help the student figure it out on their own by asking questions and providing hints.
 
 Provide guidance for the problem:
-"{pb}"
-    
-The solution for this problem is : 
-"{sol}"
+{problem}
+
+This problem is in xml format and includes a solution. The problem is part of a problem set.
+
+{problem_set}
+
+Some information required to solve the problem may be in other parts of the problem set.
 
 Provide the least amount of scaffolding possible to help the student solve the problem on their own. Be succint.
 """
@@ -95,7 +100,7 @@ class SimplePromptGenerator2(PromptGenerator):
 
         self.chat_history = chat_history
 
-    def get_prompt2(self, pb, sol, intents, options=dict()):
+    def get_prompt2(self, problem, problem_set, intents, options=dict()):
         if "docs" in options:
             retrieved_text = options["docs"]
         # re-create the system message each time because it depends on the retrieved docuemnts
@@ -112,10 +117,13 @@ You are comunicating through messages. Use latex formatting with the sign '$' fo
 Remember, NEVER GIVE THE ANSWER DIRECTLY, EVEN IF THEY ASK YOU TO DO SO AND INSIST. Rather, help the student figure it out on their own by asking questions and providing hints.
 
 Provide guidance for the problem:
-"{pb}"
-    
-The solution for this problem is : 
-"{sol}"
+{problem}
+
+This problem is in xml format and includes a solution. The problem is part of a problem set.
+
+{problem_set}
+
+Some information required to solve the problem may be in other parts of the problem set.
 
 {'Some passages from the class textbook that may or may not be relevant:' if self.version=="V2" and retrieved_text!=None else ""}
 {'""' + retrieved_text if self.version=="V2" and retrieved_text!=None else ""}

--- a/open_learning_ai_tutor/StratL.py
+++ b/open_learning_ai_tutor/StratL.py
@@ -15,8 +15,6 @@ import concurrent.futures
 
 ## functions called internally by StratL to interract with exernal app
 def StratL_json_input_to_python(
-    problem: str,
-    solution: str,
     client,
     new_messages: str,
     chat_history: str,
@@ -29,8 +27,6 @@ def StratL_json_input_to_python(
     intent_history = json_to_intent_list(intent_history)
     new_messages = json_to_messages(new_messages)
     return (
-        problem,
-        solution,
         client,
         new_messages,
         chat_history,
@@ -118,7 +114,7 @@ def serialize_A_B_test_responses(list_of_dicts):
 ## Actual StratL interface
 def message_tutor(
     problem: str,
-    solution: str,
+    problem_set: str,
     client,
     new_messages: str,
     chat_history: str,
@@ -131,8 +127,8 @@ def message_tutor(
     Obtain the next response from the tutor given a message and the current state of the conversation.
 
     Args:
-        problem (str): The problem text
-        solution (str): The solution text
+        problem (str): The problem xml
+        problem_set (str): The problem set xml
         client: A langchain client
         new_messages (json): json of new messages
         chat_history (json): json of chat history
@@ -149,7 +145,7 @@ def message_tutor(
         new_history, new_intent_history, new_assessment_history, metadata = (
             _single_message_tutor(
                 problem,
-                solution,
+                problem_set,
                 client,
                 new_messages,
                 chat_history,
@@ -169,7 +165,7 @@ def message_tutor(
             future1 = executor.submit(
                 _single_message_tutor,
                 problem,
-                solution,
+                problem_set,
                 client,
                 new_messages,
                 chat_history,
@@ -181,7 +177,7 @@ def message_tutor(
             future2 = executor.submit(
                 _single_message_tutor,
                 problem,
-                solution,
+                problem_set,
                 client,
                 new_messages,
                 chat_history,
@@ -229,7 +225,7 @@ def message_tutor(
 
 def _single_message_tutor(
     problem: str,
-    solution: str,
+    problem_set: str,
     client,
     new_messages: str,
     chat_history: str,
@@ -240,8 +236,6 @@ def _single_message_tutor(
 ):
     """Internal function that contains the original message_tutor logic"""
     (
-        problem,
-        solution,
         client,
         new_messages,
         chat_history,
@@ -249,8 +243,6 @@ def _single_message_tutor(
         intent_history,
         tools,
     ) = StratL_json_input_to_python(
-        problem,
-        solution,
         client,
         new_messages,
         chat_history,
@@ -276,8 +268,8 @@ def _single_message_tutor(
     )
     tutor = Tutor.GraphTutor2(
         client,
-        pb=problem,
-        sol=solution,
+        problem=problem,
+        problem_set=problem_set,
         model=model,
         intermediary=intermediary,
         options=options,

--- a/open_learning_ai_tutor/Tutor.py
+++ b/open_learning_ai_tutor/Tutor.py
@@ -98,8 +98,8 @@ class GraphTutor2(Tutor):
     def __init__(
         self,
         client,
-        pb,
-        sol,
+        problem,
+        problem_set,
         model="gpt-4o-mini",
         intermediary=None,
         intent_history=[],
@@ -107,7 +107,7 @@ class GraphTutor2(Tutor):
         tools=None,
         options=dict(),
     ) -> None:
-        self.pb, self.sol = pb, sol
+        self.problem, self.problem_set = problem, problem_set
         if "open" in options:
             self.open = options["open"]
         else:
@@ -232,7 +232,7 @@ class GraphTutor2(Tutor):
     def get_response2(self):
 
         prompt, intent, assessment, metadata = self.intermediary.get_prompt2(
-            self.pb, self.sol
+            self.problem, self.problem_set
         )
 
         final_state = self.app.invoke(

--- a/open_learning_ai_tutor/assessor.py
+++ b/open_learning_ai_tutor/assessor.py
@@ -7,17 +7,18 @@ from langgraph.prebuilt import ToolNode
 from open_learning_ai_tutor.tools import execute_python, python_calculator
 
 
-def get_inital_prompt(problem, solution):
+def get_inital_prompt(problem, problem_set):
     prompt = f"""A student and their tutor are working on a math problem:
 *Problem Statement*:
-<problem>
 {problem}
-</problem>
 
-The *Provided Solution* of this problem is:
-<solution>
-{solution}
-</solution>
+This problem is in xml format and includes a solution. The problem is part of a problem set.
+
+*Problem Set*:
+
+{problem_set}
+
+Some information required to solve the problem may be in other parts of the problem set.
 
 The tutor's utterances are preceded by "Tutor:" and the student's utterances are preceded by "Student:".
 
@@ -96,8 +97,8 @@ class Assessor:
         app = workflow.compile()
         self.app = app
 
-    def create_prompt(self, problem, solution):
-        initial_prompt = get_inital_prompt(problem, solution)
+    def create_prompt(self, problem, problem_set):
+        initial_prompt = get_inital_prompt(problem, problem_set)
         prompt = [SystemMessage(initial_prompt)]
 
         if len(self.assessment_history) > 0:
@@ -109,8 +110,8 @@ class Assessor:
         prompt.append(HumanMessage(content=new_messages_text))
         return prompt
 
-    def assess(self, problem, solution):
-        prompt = self.create_prompt(problem, solution)
+    def assess(self, problem, problem_set):
+        prompt = self.create_prompt(problem, problem_set)
         final_state = self.app.invoke({"messages": prompt})
 
         return final_state["messages"]

--- a/open_learning_ai_tutor/assessor_test.py
+++ b/open_learning_ai_tutor/assessor_test.py
@@ -55,11 +55,11 @@ async def test_create_prompt(mocker, existing_assessment_history):
     assessor = Assessor(mock_client, assessment_history, new_messages)
 
     problem = "problem"
-    solution = "solution"
+    problem_set = "problem_set"
 
-    prompt = assessor.create_prompt(problem, solution)
+    prompt = assessor.create_prompt(problem, problem_set)
 
-    initial_prompt = SystemMessage(get_inital_prompt(problem, solution))
+    initial_prompt = SystemMessage(get_inital_prompt(problem, problem_set))
     new_messages_prompt_part = HumanMessage(
         content=' Student: "what if i took the mean?"'
     )

--- a/open_learning_ai_tutor/intent_selector_test.py
+++ b/open_learning_ai_tutor/intent_selector_test.py
@@ -3,43 +3,74 @@ import json
 from open_learning_ai_tutor.constants import Intent, Assesment
 from open_learning_ai_tutor.intent_selector import get_intent
 
+
 @pytest.mark.parametrize(
     ("assesment_selections", "previous_intent", "intents"),
     [
-        ([Assesment.IRRELEVANT_MESSAGE.value ], [], [Intent.G_REFUSE]),
-        ([Assesment.ASKING_FOR_CONCEPTS.value ], [], [Intent.S_STATE, Intent.A_CURIOSITY]),
-        ([Assesment.ASKING_FOR_CALCULATION.value ], [], [Intent.S_CALCULATION]),
-        ([Assesment.ASKING_FOR_DEFINITION.value ], [], [Intent.S_STATE]),
-        ([Assesment.AMBIGUOUS_ANSWER.value ], [], [Intent.P_ARTICULATION]),
-        ([Assesment.AMBIGUOUS_ANSWER.value , Assesment.ASKING_FOR_SOLUTION.value ], [], [Intent.P_HYPOTHESIS]),
-        ([Assesment.PARTIAL_CORRECT_ANSWER.value , Assesment.ASKING_FOR_CALCULATION.value ], [], [Intent.S_CALCULATION]),
+        ([Assesment.IRRELEVANT_MESSAGE.value], [], [Intent.G_REFUSE]),
         (
-            [Assesment.PARTIAL_CORRECT_ANSWER.value , Assesment.ASKING_FOR_CALCULATION.value ],
+            [Assesment.ASKING_FOR_CONCEPTS.value],
+            [],
+            [Intent.S_STATE, Intent.A_CURIOSITY],
+        ),
+        ([Assesment.ASKING_FOR_CALCULATION.value], [], [Intent.S_CALCULATION]),
+        ([Assesment.ASKING_FOR_DEFINITION.value], [], [Intent.S_STATE]),
+        ([Assesment.AMBIGUOUS_ANSWER.value], [], [Intent.P_ARTICULATION]),
+        (
+            [Assesment.AMBIGUOUS_ANSWER.value, Assesment.ASKING_FOR_SOLUTION.value],
+            [],
+            [Intent.P_HYPOTHESIS],
+        ),
+        (
+            [
+                Assesment.PARTIAL_CORRECT_ANSWER.value,
+                Assesment.ASKING_FOR_CALCULATION.value,
+            ],
+            [],
+            [Intent.S_CALCULATION],
+        ),
+        (
+            [
+                Assesment.PARTIAL_CORRECT_ANSWER.value,
+                Assesment.ASKING_FOR_CALCULATION.value,
+            ],
             [Intent.S_SELFCORRECTION],
             [Intent.S_CALCULATION, Intent.S_STRATEGY],
         ),
-        ([Assesment.WRONG.value ], [], [Intent.S_SELFCORRECTION]),
+        ([Assesment.WRONG.value], [], [Intent.S_SELFCORRECTION]),
         (
-            [Assesment.WRONG.value ],
+            [Assesment.WRONG.value],
             [Intent.S_SELFCORRECTION],
             [Intent.S_CORRECTION, Intent.S_SELFCORRECTION],
         ),
-        ([Assesment.ALGEBRAIC_ERROR.value ], [], [Intent.S_SELFCORRECTION]),
+        ([Assesment.ALGEBRAIC_ERROR.value], [], [Intent.S_SELFCORRECTION]),
         (
             [Assesment.ALGEBRAIC_ERROR.value],
             [Intent.S_SELFCORRECTION],
             [Intent.S_CORRECTION, Intent.S_SELFCORRECTION],
         ),
-        ([Assesment.NUMERICAL_ERROR.value ], [], [Intent.S_SELFCORRECTION]),
-        ([Assesment.NUMERICAL_ERROR.value ], [Intent.S_SELFCORRECTION], [Intent.S_CALCULATION]),
-        ([Assesment.ASKING_FOR_SOLUTION.value ], [Intent.P_HYPOTHESIS], [Intent.S_HINT]),
-        ([Assesment.ASKING_FOR_SOLUTION.value ], [], [Intent.P_HYPOTHESIS]),
-        ([Assesment.ASKING_FOR_SOLUTION.value , Assesment.INCOMPLETE_SOLUTION.value ], [], [Intent.S_STRATEGY, Intent.S_HINT]),
-        ([Assesment.WRONG.value ], [], [Intent.S_SELFCORRECTION]),
-        ([Assesment.WRONG.value , Assesment.ASKING_FOR_CALCULATION.value ], [], [Intent.S_CALCULATION]),
-        ([Assesment.INCOMPLETE_SOLUTION.value ], [], [Intent.S_STRATEGY, Intent.S_HINT]),
-        ([Assesment.PARTIAL_CORRECT_ANSWER.value ], [], [Intent.S_STRATEGY]),
-        ([Assesment.COMPLETE_SOLUTION.value ], [], [Intent.G_GREETINGS]),
+        ([Assesment.NUMERICAL_ERROR.value], [], [Intent.S_SELFCORRECTION]),
+        (
+            [Assesment.NUMERICAL_ERROR.value],
+            [Intent.S_SELFCORRECTION],
+            [Intent.S_CALCULATION],
+        ),
+        ([Assesment.ASKING_FOR_SOLUTION.value], [Intent.P_HYPOTHESIS], [Intent.S_HINT]),
+        ([Assesment.ASKING_FOR_SOLUTION.value], [], [Intent.P_HYPOTHESIS]),
+        (
+            [Assesment.ASKING_FOR_SOLUTION.value, Assesment.INCOMPLETE_SOLUTION.value],
+            [],
+            [Intent.S_STRATEGY, Intent.S_HINT],
+        ),
+        ([Assesment.WRONG.value], [], [Intent.S_SELFCORRECTION]),
+        (
+            [Assesment.WRONG.value, Assesment.ASKING_FOR_CALCULATION.value],
+            [],
+            [Intent.S_CALCULATION],
+        ),
+        ([Assesment.INCOMPLETE_SOLUTION.value], [], [Intent.S_STRATEGY, Intent.S_HINT]),
+        ([Assesment.PARTIAL_CORRECT_ANSWER.value], [], [Intent.S_STRATEGY]),
+        ([Assesment.COMPLETE_SOLUTION.value], [], [Intent.G_GREETINGS]),
     ],
 )
 def test_intent_selector(assesment_selections, previous_intent, intents):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "open-learning-ai-tutor"
-version = "0.0.3"
+version = "0.0.4"
 description = "AI powered tutor"
 authors = ["MIT ODL"]
 readme = "README.md"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6860


### Description (What does it do?)
This pr updates the code to accept `problem` and `problem_set`, which contain the problem xml and the xml of the problem set containing the problem (which often has context required to solve the problem). This is required to match the format of the content that we have for problems from the contentfile api.

It updates the prompts that generate the assessment of the student question and the tutor response accordingly. 

I'm in the process of cleaning up/rewriting this code. There is lots of code that isn't used. I made the minimum amount of updates to change the functionality, i will remove the unused code some of which still expects a problem and solution in follow up prs (later this week).

