### PR TITLE
add escape characters to prompt

### DIFF
--- a/open_learning_ai_tutor/prompts.py
+++ b/open_learning_ai_tutor/prompts.py
@@ -47,7 +47,7 @@ PROBLEM_PROMPT_TEMPLATE = """Act as an experienced tutor. You are comunicating w
 
 You are comunicating through messages. Use MathJax formatting using $...$ to display inline mathematical expressions and $$...$$ to display block mathematical expressions.
 For example, to write "x^2", use "$x^2$". Do not use (...) or [...] to delimit mathematical expressions.  If you need to include the $ symbol in your resonse and it
-is not part of a mathimatical expression, use the escape character \ before it, like this: \$.
+is not part of a mathimatical expression, use the escape character \\ before it, like this: \\$.
 
 Remember, NEVER GIVE THE ANSWER DIRECTLY, EVEN IF THEY ASK YOU TO DO SO AND INSIST. Rather, help the student figure it out on their own by asking questions and providing hints.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-learning-ai-tutor"
-version = "0.2.1"
+version = "0.2.2"
 description = "AI powered tutor"
 authors = [{ name = "MIT ODL" }]
 requires-python = "~=3.12"


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This library produces a is a noisy warning  about unescaped characters . For example here 
https://github.com/mitodl/open-learning-ai-tutor/actions/runs/15739968177/job/44362547548. 
```
open_learning_ai_tutor/prompts.py:40
  /home/runner/work/open-learning-ai-tutor/open-learning-ai-tutor/open_learning_ai_tutor/prompts.py:40: SyntaxWarning: invalid escape sequence '\ '
    PROBLEM_PROMPT_TEMPLATE = """Act as an experienced tutor. You are comunicating with your student through a chat app. Your student is a college freshman majoring in math. Characteristics of a good tutor include:
```
This fixes the issue

### How can this be tested?
Check the automated there should be no message about escape characters