### PR TITLE
dont send assessment history to assessor

### DIFF
--- a/open_learning_ai_tutor/message_tutor.py
+++ b/open_learning_ai_tutor/message_tutor.py
@@ -36,11 +36,9 @@ def message_tutor(
         client,
         tools=tools,
     )
-    assessment_prompt = get_assessment_prompt(
-        problem, problem_set, assessment_history, new_messages
-    )
+    assessment_prompt = get_assessment_prompt(problem, problem_set, new_messages)
     assessment_response = tutor.get_response(assessment_prompt)
-    new_assessment_history = assessment_response["messages"]
+    new_assessment_history = assessment_history + assessment_response["messages"][1:]
     if len(new_assessment_history) <= 1:
         raise ValueError("Something went wrong. The assessment history is empty.")
 
@@ -53,9 +51,6 @@ def message_tutor(
         chat_history,
         new_intent,
     )
-    new_assessment_history = new_assessment_history[
-        1:
-    ]  # [1:] because we don't include system prompt
 
     new_intent_history = intent_history + [new_intent]
 

--- a/open_learning_ai_tutor/message_tutor_test.py
+++ b/open_learning_ai_tutor/message_tutor_test.py
@@ -37,7 +37,10 @@ def test_message_tutor(mocker):
     client.model_name = "test_model"
     new_messages = [HumanMessage(content="what should i try first")]
     chat_history = [HumanMessage(content="what should i try first")]
-    assessment_history = []
+    assessment_history = [
+        HumanMessage(content='Student: "i am confused"'),
+        AIMessage(content='{"justification": "test", "selection": "c"}'),
+    ]
     intent_history = []
     tools = []
 
@@ -59,6 +62,16 @@ def test_message_tutor(mocker):
             [Intent.P_HYPOTHESIS],
         ],
         [
+            HumanMessage(
+                content='Student: "i am confused"',
+                additional_kwargs={},
+                response_metadata={},
+            ),
+            AIMessage(
+                content='{"justification": "test", "selection": "c"}',
+                additional_kwargs={},
+                response_metadata={},
+            ),
             HumanMessage(
                 content='Student: "what should i try first"',
                 additional_kwargs={},

--- a/open_learning_ai_tutor/prompts.py
+++ b/open_learning_ai_tutor/prompts.py
@@ -164,12 +164,9 @@ def get_assessment_initial_prompt(problem, problem_set):
     )
 
 
-def get_assessment_prompt(problem, problem_set, assessment_history, new_messages):
+def get_assessment_prompt(problem, problem_set, new_messages):
     initial_prompt = get_assessment_initial_prompt(problem, problem_set)
     prompt = [SystemMessage(initial_prompt)]
-
-    if len(assessment_history) > 0:
-        prompt = prompt + assessment_history
 
     new_messages_text = ""
     for message in new_messages:

--- a/open_learning_ai_tutor/prompts_test.py
+++ b/open_learning_ai_tutor/prompts_test.py
@@ -91,41 +91,21 @@ def test_intent_prompt(intents, message):
     assert get_intent_prompt(intents) == message
 
 
-@pytest.mark.parametrize("existing_assessment_history", [True, False])
-def test_get_assessment_prompt(mocker, existing_assessment_history):
+def test_get_assessment_prompt(mocker):
     """Test that the Assessor create_prompt method returns the correct prompt."""
-    if existing_assessment_history:
-        assessment_history = [
-            HumanMessage(content=' Student: "what do i do next?"'),
-            AIMessage(
-                content='{\n    "justification": "The student is explicitly asking for guidance on how to proceed with solving the problem, indicating they are unsure of the next steps.",\n    "selection": "g"\n}'
-            ),
-        ]
-    else:
-        assessment_history = []
-
     new_messages = [HumanMessage(content="what if i took the mean?")]
 
     problem = "problem"
     problem_set = "problem_set"
 
-    prompt = get_assessment_prompt(
-        problem, problem_set, assessment_history, new_messages
-    )
+    prompt = get_assessment_prompt(problem, problem_set, new_messages)
 
     initial_prompt = SystemMessage(get_assessment_initial_prompt(problem, problem_set))
     new_messages_prompt_part = HumanMessage(
         content=' Student: "what if i took the mean?"'
     )
 
-    if existing_assessment_history:
-        expected_prompt = [
-            initial_prompt,
-            *assessment_history,
-            new_messages_prompt_part,
-        ]
-    else:
-        expected_prompt = [initial_prompt, new_messages_prompt_part]
+    expected_prompt = [initial_prompt, new_messages_prompt_part]
     assert prompt == expected_prompt
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-learning-ai-tutor"
-version = "0.2.3"
+version = "0.2.4"
 description = "AI powered tutor"
 authors = [{ name = "MIT ODL" }]
 requires-python = "~=3.12"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7783

### Description (What does it do?)
Currently the prompt to generate the assessment of the student intent instructs the ai to only consider the latest message but the full assessment history is sent as part of the prompt. We can save money by only sending the latest message

### How can this be tested?
Checkout https://github.com/mitodl/learn-ai/tree/ab/dont-send-assessment-history-to-assessor
Verify that the tutor works the same as previously