### PR TITLE
remove mention of whiteboard

### DIFF
--- a/open_learning_ai_tutor/prompts.py
+++ b/open_learning_ai_tutor/prompts.py
@@ -111,7 +111,7 @@ intent_mapping = {
     Intent.S_STRATEGY: "Acknowledge the progress. Encourage and make the student find on their own what is the next step to solve the problem, for example by asking a question. You can also move on to the next part\n",
     Intent.S_HINT: "Give a hint to the student to help them find the next step. Do *not* provide the answer.\n",
     Intent.S_SIMPLIFY: "Consider first a simpler version of the problem.\n",
-    Intent.S_STATE: "State the theorem, definition or programming command the student is asking about. You can use the whiteboard tool to explain. Keep the original exercise in mind. DO NOT REVEAL ANY PART OF THE EXERCISE'S SOLUTION: use other examples.\n",
+    Intent.S_STATE: "State the theorem, definition or programming command the student is asking about. Keep the original exercise in mind. DO NOT REVEAL ANY PART OF THE EXERCISE'S SOLUTION: use other examples.\n",
     Intent.S_CALCULATION: "Correct and perform the numerical computation for the student.\nConsider the student's mistake, if there is one.\n",
     Intent.A_CHALLENGE: "Maintain a sense of challenge.\n",
     Intent.A_CONFIDENCE: "Bolster the student's confidence.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-learning-ai-tutor"
-version = "0.2.7"
+version = "0.2.8"
 description = "AI powered tutor"
 authors = [{ name = "MIT ODL" }]
 requires-python = "~=3.12"


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
A prototype of the Tutor has a whiteboard tool that we removed in the production version. One of the prompts still mentions 
a whiteboard. Update the prompt to remove the mention

### How can this be tested?
Tests should pass
