### PR TITLE
enable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>mitodl/.github:renovate-config"]
+}


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This pr enables renovate to run on open-learning-ai-tutor

Currently langgraph/langchain/langsmith are outdated on  open-learning-ai-tutor and that's blocking a security renovate update of langchain in learn-ai. Getting renovate prs for this repo will make keeping learn-ai up to date on renovate easier.

open-learning-ai-tutor is included in the mend dashboard https://developer.mend.io/github/mitodl/open-learning-ai-tutor but renovate does not currently run for it since there is no cofig file.

### How to test

I'm not sure. The plan is to merge it and check if renovate creates a dependency dashboard.
