### PR TITLE
forkProcessing: enabled

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>mitodl/.github:renovate-config"]
+  "extends": ["local>mitodl/.github:renovate-config"],
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/open-learning-ai-tutor/pull/52 did not work since this branch is a fork so requires an extra config. 

debug from the run 
https://developer.mend.io/github/mitodl/open-learning-ai-tutor/-/job/5b964a20-0735-48b9-a9c6-4c261f97f220

was 
```
DEBUG: Default config file renovate.json found in repo but does not enable forks
{
  "config": {
    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
    "extends": [
      "local>mitodl/.github:renovate-config"
    ]
  }
}

INFO: Repository is a fork and not manually configured - skipping - did you want to run with --fork-processing=enabled?
DEBUG: Removing any stale branches
DEBUG: config.repoIsOnboarded=undefined
DEBUG: No defaultBranch set - skipping branch pruning
```